### PR TITLE
Updated scalaz to latest, 7.0.0-M8.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 name := "machines"
 
-libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.0.0-M7"
+libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.0.0-M8"
 
-libraryDependencies += "org.scalaz" %% "scalaz-effect" % "7.0.0-M7"
+libraryDependencies += "org.scalaz" %% "scalaz-effect" % "7.0.0-M8"
 
 libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.10.0" % "test"
 


### PR DESCRIPTION
None of the changes for M8 affected scala-machines.
