### PR TITLE
Fixed replicateM_ in Plan.

### DIFF
--- a/src/main/scala/com/clarifi/machines/Plan.scala
+++ b/src/main/scala/com/clarifi/machines/Plan.scala
@@ -82,7 +82,7 @@ sealed trait Plan[+K, +O, +A] {
 
   /** Repeat this plan `n` times. */
   def replicateM_(n: Int): Plan[K, O, Unit] = n match {
-    case 0 => Return(())
+    case n if n <= 0 => Return(())
     case n => this >> this.replicateM_(n - 1)
   }
 


### PR DESCRIPTION
I fixed a bug that causes an infinite recursion when supply a negative number as the argument to Plan.replicateM_.
